### PR TITLE
Notify ViewObservers of existing views

### DIFF
--- a/gui/src/pluginmanager.cc
+++ b/gui/src/pluginmanager.cc
@@ -237,6 +237,8 @@ void PluginManager::registerViewObserver(const std::string& identifier, ViewObse
 {
   printf("Observing Views for %s!\n", identifier.c_str());
   viewObservers[observer] = identifier;
+
+  on_new_viewobserver(observer);
 }
 
 void PluginManager::registerPresentationObserver(const std::string& identifier, PresentationObserver::Ptr observer)


### PR DESCRIPTION
As discussed before the first view is currently created before the plugins have finished loading (unless you pass a file via the command line). Therefore a plugin that implements `ViewObserver` never gets notified of the first view.

This commit fixes that by passing all existing views to a new `ViewObserver` as soon as it is registered. It's also worth noting that a similar code path already exists for plugins of the `newPresentationInterface` type.

I've done some testing and this fix does address the issue I was running into. I ran a `grep` on the code base but couldn't find any existing plugins of the `ViewObserver` to test for possible regressions.