### PR TITLE
Allow plugins to load presentations

### DIFF
--- a/gui/src/callbacks.cc
+++ b/gui/src/callbacks.cc
@@ -603,3 +603,7 @@ void on_new_viewobserver(ViewObserver::Ptr v)
   }
 }
 
+PresentationInterface::Ptr on_load_presentation(const std::string& filename)
+{
+  return loadPresentation(filename);
+}

--- a/gui/src/callbacks.hh
+++ b/gui/src/callbacks.hh
@@ -78,3 +78,5 @@ void on_new_presentationobserver(PresentationObserver::Ptr po);
 void on_new_viewobserver(ViewObserver::Ptr v);
 
 void on_presentation_possibly_destroyed();
+
+PresentationInterface::Ptr on_load_presentation(const std::string& filename);

--- a/gui/src/pluginmanager.cc
+++ b/gui/src/pluginmanager.cc
@@ -247,6 +247,11 @@ void PluginManager::registerPresentationObserver(const std::string& identifier, 
   presentationObservers[observer] = identifier;
 }
 
+PresentationInterface::Ptr PluginManager::loadPresentation(const std::string& filename)
+{
+  return on_load_presentation(filename);
+}
+
 const std::map<NewPresentationInterface::Ptr, std::string>& PluginManager::getNewPresentationInterfaces()
 {
   return newPresentationInterfaces;

--- a/gui/src/pluginmanager.hh
+++ b/gui/src/pluginmanager.hh
@@ -79,6 +79,8 @@ public:
   virtual void registerViewObserver(const std::string& identifier, ViewObserver::Ptr observer);
   virtual void registerPresentationObserver(const std::string& identifier, PresentationObserver::Ptr observer);
 
+  virtual PresentationInterface::Ptr loadPresentation(const std::string& filename);
+
   const std::map<NewPresentationInterface::Ptr, std::string>& getNewPresentationInterfaces();
   const std::map<std::string, NewAggregateInterface::Ptr>& getNewAggregateInterfaces();
   const std::map<OpenPresentationInterface::Ptr, std::string>& getOpenPresentationInterfaces();

--- a/inc/scroom/scroominterface.hh
+++ b/inc/scroom/scroominterface.hh
@@ -118,5 +118,7 @@ public:
   virtual void registerOpenInterface(const std::string& identifier, OpenInterface::Ptr openInterface)=0;
   virtual void registerViewObserver(const std::string& identifier, ViewObserver::Ptr observer)=0;
   virtual void registerPresentationObserver(const std::string& identifier, PresentationObserver::Ptr observer)=0;
+
+  virtual PresentationInterface::Ptr loadPresentation(const std::string& filename)=0;
 };
 


### PR DESCRIPTION
The aim of this change was to enable plugins to load presentations on their own. The main use case for this being a plugin that does something with a set of presentations, a possible alternative use case a plugin that changes the presentation on display in a view. 

Currently compiling against another plugin and directly calling that plugin to parse a file to open a presentation is the best alternative. However, this is a solution that fails if a plugin is not present and limited to plugins that are known to exist. The solution in this PR allows a plugin to ask Scroom to open any file and Scroom will figure out which plugin type is capable of opening the file.

When trying to add a code path for this the `ScroomPluginInterface` seemed to me as the best place to add this as it is the only thing shared by all plugin types that also has the ability interact directly with Scroom. I'm not sure however, if a better alternative may have been available. This would also be the first addition to the `ScroomPluginInterface` that is not strictly for registering a new plugin.

Anyway, let me know what you think @kees-jan (did that trigger an email notification?).