### PR TITLE
Suppress console for Windows build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,13 @@ SCROOM_ADD_CXXFLAGS_IF_SUPPORTED([-Wnon-virtual-dtor])
 SCROOM_ADD_CXXFLAGS_IF_SUPPORTED([-Woverloaded-virtual])
 SCROOM_ADD_CXXFLAGS_IF_SUPPORTED([-Wsign-promo])
 SCROOM_ADD_CXXFLAGS_IF_SUPPORTED([-Wshadow])
+
+dnl Compile with -mwindows to suppress a new console from opening if the executable is not started from a console
+dnl This does not suppress the stdout and stderr streams. These are still visible if scroom.exe is started from a 
+dnl command prompt/console.
 dnl SCROOM_ADD_CXXFLAGS_IF_SUPPORTED([-mwindows])
+AM_COND_IF([WINDOWS], 
+    [LDFLAGS="$LDFLAGS -mwindows"])
 SCROOM_TEST_ISYSTEM
 
 # Disabled warnings


### PR DESCRIPTION
Do not show a new console when the executable is started outside of a console. The stdout and stderr are still visible when the user starts scroom.exe from the command line.

This is sufficient for most users, and for extra debugging we can ask the users encountering a problem to open scroom.exe from the command line.