### PR TITLE
pixel-averages-update

### DIFF
--- a/inc/scroom/layeroperations.hh
+++ b/inc/scroom/layeroperations.hh
@@ -30,20 +30,13 @@ public:
                     Scroom::Utils::Stuff cache);
 };
 
-class PipetteCommonOperations : public CommonOperations, public PipetteLayerOperations
-{
-public:
-  typedef boost::shared_ptr<PipetteCommonOperations> Ptr;
-
-public:
-  virtual ~PipetteCommonOperations()
-  {}
-};
-
-class PipetteCommonOperationsCMYK : public PipetteCommonOperations
+class PipetteCommonOperationsCMYK : public PipetteLayerOperations, public CommonOperations
 {
 protected:
   int bps;
+
+public:
+  typedef boost::shared_ptr<PipetteCommonOperationsCMYK> Ptr;
 
 public:
   PipetteCommonOperationsCMYK(int bps_) : bps(bps_) {};
@@ -53,10 +46,13 @@ public:
   PipetteLayerOperations::PipetteColor sumPixelValues(Scroom::Utils::Rectangle<int> area, const ConstTile::Ptr tile);
 };
 
-class PipetteCommonOperationsRGB : public PipetteCommonOperations
+class PipetteCommonOperationsRGB : public PipetteLayerOperations, public CommonOperations
 {
 protected:
   int bps;
+
+public:
+  typedef boost::shared_ptr<PipetteCommonOperationsRGB> Ptr;
 
 public:
   PipetteCommonOperationsRGB(int bps_) : bps(bps_) {};
@@ -109,8 +105,8 @@ public:
 class Operations24bpp : public PipetteCommonOperationsRGB
 {
 public:
-  static PipetteCommonOperations::Ptr create(int bps);
-  Operations24bpp(int bps);
+  static Ptr create();
+  Operations24bpp();
   virtual ~Operations24bpp()
   {}
 
@@ -182,8 +178,8 @@ public:
 class OperationsCMYK32 : public PipetteCommonOperationsCMYK
 {
 public:
-  static PipetteCommonOperations::Ptr create(int bps);
-  OperationsCMYK32(int bps);
+  static Ptr create();
+  OperationsCMYK32();
   virtual ~OperationsCMYK32()
   {}
 
@@ -195,8 +191,8 @@ public:
 class OperationsCMYK16 : public PipetteCommonOperationsCMYK
 {
 public:
-  static PipetteCommonOperations::Ptr create(int bps);
-  OperationsCMYK16(int bps);
+  static Ptr create();
+  OperationsCMYK16();
   virtual ~OperationsCMYK16()
   {}
 
@@ -208,8 +204,8 @@ public:
 class OperationsCMYK8 : public PipetteCommonOperationsCMYK
 {
 public:
-  static PipetteCommonOperations::Ptr create(int bps);
-  OperationsCMYK8(int bps);
+  static Ptr create();
+  OperationsCMYK8();
   virtual ~OperationsCMYK8()
   {}
 
@@ -221,8 +217,8 @@ public:
 class OperationsCMYK4 : public PipetteCommonOperationsCMYK
 {
 public:
-  static PipetteCommonOperations::Ptr create(int bps);
-  OperationsCMYK4(int bps);
+  static Ptr create();
+  OperationsCMYK4();
   virtual ~OperationsCMYK4()
   {}
 

--- a/libs/tiled-bitmap/src/cmyklayeroperations.cc
+++ b/libs/tiled-bitmap/src/cmyklayeroperations.cc
@@ -21,12 +21,12 @@ namespace
 ////////////////////////////////////////////////////////////////////////
 // OperationsCMYK32
 
-PipetteCommonOperations::Ptr OperationsCMYK32::create(int bps)
+PipetteCommonOperationsCMYK::Ptr OperationsCMYK32::create()
 {
-  return PipetteCommonOperations::Ptr(new OperationsCMYK32(bps));
+  return PipetteCommonOperationsCMYK::Ptr(new OperationsCMYK32());
 }
 
-OperationsCMYK32::OperationsCMYK32(int bps_) : PipetteCommonOperationsCMYK(bps_)
+OperationsCMYK32::OperationsCMYK32() : PipetteCommonOperationsCMYK(8)
 {
 }
 
@@ -120,12 +120,12 @@ void OperationsCMYK32::reduce(Tile::Ptr target, const ConstTile::Ptr source, int
 ////////////////////////////////////////////////////////////////////////
 // OperationsCMYK16
 
-PipetteCommonOperations::Ptr OperationsCMYK16::create(int bps)
+PipetteCommonOperationsCMYK::Ptr OperationsCMYK16::create()
 {
-  return PipetteCommonOperations::Ptr(new OperationsCMYK16(bps));
+  return PipetteCommonOperationsCMYK::Ptr(new OperationsCMYK16());
 }
 
-OperationsCMYK16::OperationsCMYK16(int bps_) : PipetteCommonOperationsCMYK(bps_)
+OperationsCMYK16::OperationsCMYK16() : PipetteCommonOperationsCMYK(4)
 {
 }
 
@@ -219,12 +219,12 @@ void OperationsCMYK16::reduce(Tile::Ptr target, const ConstTile::Ptr source, int
 ////////////////////////////////////////////////////////////////////////
 // OperationsCMYK8
 
-PipetteCommonOperations::Ptr OperationsCMYK8::create(int bps)
+PipetteCommonOperationsCMYK::Ptr OperationsCMYK8::create()
 {
-  return PipetteCommonOperations::Ptr(new OperationsCMYK8(bps));
+  return PipetteCommonOperationsCMYK::Ptr(new OperationsCMYK8());
 }
 
-OperationsCMYK8::OperationsCMYK8(int bps_) : PipetteCommonOperationsCMYK(bps_)
+OperationsCMYK8::OperationsCMYK8() : PipetteCommonOperationsCMYK(2)
 {
 }
 
@@ -315,12 +315,12 @@ void OperationsCMYK8::reduce(Tile::Ptr target, const ConstTile::Ptr source, int 
 ////////////////////////////////////////////////////////////////////////
 // OperationsCMYK4
 
-PipetteCommonOperations::Ptr OperationsCMYK4::create(int bps)
+PipetteCommonOperationsCMYK::Ptr OperationsCMYK4::create()
 {
-  return PipetteCommonOperations::Ptr(new OperationsCMYK4(bps));
+  return PipetteCommonOperationsCMYK::Ptr(new OperationsCMYK4());
 }
 
-OperationsCMYK4::OperationsCMYK4(int bps_) : PipetteCommonOperationsCMYK(bps_)
+OperationsCMYK4::OperationsCMYK4() : PipetteCommonOperationsCMYK(1)
 {
 }
 

--- a/libs/tiled-bitmap/src/layeroperations.cc
+++ b/libs/tiled-bitmap/src/layeroperations.cc
@@ -507,12 +507,12 @@ void Operations8bpp::draw(cairo_t* cr, const ConstTile::Ptr tile,
 ////////////////////////////////////////////////////////////////////////
 // Operations24bpp
 
-PipetteCommonOperations::Ptr Operations24bpp::create(int bps)
+PipetteCommonOperationsRGB::Ptr Operations24bpp::create()
 {
-  return PipetteCommonOperations::Ptr(new Operations24bpp(bps));
+  return PipetteCommonOperationsRGB::Ptr(new Operations24bpp());
 }
 
-Operations24bpp::Operations24bpp(int bps_) : PipetteCommonOperationsRGB(bps_)
+Operations24bpp::Operations24bpp() : PipetteCommonOperationsRGB(8)
 {
 }
 

--- a/plugins/tiff/src/tiffpresentation.cc
+++ b/plugins/tiff/src/tiffpresentation.cc
@@ -198,38 +198,38 @@ bool TiffPresentation::load(const std::string& fileName_)
     LayerSpec ls;
     if (spp == 4 && bps == 8)
     {
-      auto cmykOperations = OperationsCMYK32::create(bps);
+      auto cmykOperations = OperationsCMYK32::create();
       pipetteLayerOperation = cmykOperations;
       ls.push_back(cmykOperations);
       properties[PIPETTE_PROPERTY_NAME] = "";
     }
     else if (spp == 4 && bps == 4)
     {
-      auto cmykOperations = OperationsCMYK16::create(bps);
+      auto cmykOperations = OperationsCMYK16::create();
       pipetteLayerOperation = cmykOperations;
       ls.push_back(cmykOperations);
-      ls.push_back(OperationsCMYK32::create(8));
+      ls.push_back(OperationsCMYK32::create());
       properties[PIPETTE_PROPERTY_NAME] = "";
     }
     else if (spp == 4 && bps == 2)
     {
-      auto cmykOperations = OperationsCMYK8::create(bps);
+      auto cmykOperations = OperationsCMYK8::create();
       pipetteLayerOperation = cmykOperations;
       ls.push_back(cmykOperations);
-      ls.push_back(OperationsCMYK32::create(8));
+      ls.push_back(OperationsCMYK32::create());
       properties[PIPETTE_PROPERTY_NAME] = "";
     }
     else if (spp == 4 && bps == 1)
     {
-      auto cmykOperations = OperationsCMYK4::create(bps);
+      auto cmykOperations = OperationsCMYK4::create();
       pipetteLayerOperation = cmykOperations;
       ls.push_back(cmykOperations);
-      ls.push_back(OperationsCMYK32::create(8));
+      ls.push_back(OperationsCMYK32::create());
       properties[PIPETTE_PROPERTY_NAME] = "";
     }
     else if (spp == 3 && bps == 8)
     {
-      auto rgbOperations = Operations24bpp::create(bps);
+      auto rgbOperations = Operations24bpp::create();
       pipetteLayerOperation = rgbOperations;
       ls.push_back(rgbOperations);
       properties[PIPETTE_PROPERTY_NAME] = "";


### PR DESCRIPTION
Hi @kees-jan ,
These are the updates that were requested from #60 . 

### Changes:
- removed `bps` as parameter in `TiffPresentation.cc` and of course the `create` function does not expect it anymore.
- removed `CommonOperations` as a class as it is not needed anymore.

### Concerns:
- I did not change the datastructure for PipetteColors yet. I am currently trying out some different implementations for `sumPixelValues()`. If we can assume that the order of the vectors of the two parameters (`lhs` and `rhs`) to be the same, then it becomes a simple O(n) algorithm (there may be a simple check to make sure that `lhs` is not empty). However, I am not sure whether it is fine to have this assumption here. Without the assumption, i think the algorithm becomes a bit harder (and probably asymptotically more complex which could perhaps be avoided?). I do not really have a preference here...

regards,
Armin