### PR TITLE
changed datastructure to vectors of pairs

### DIFF
--- a/inc/scroom/pipettelayeroperations.hh
+++ b/inc/scroom/pipettelayeroperations.hh
@@ -11,27 +11,11 @@
 #include <scroom/rectangle.hh>
 #include <scroom/tile.hh>
 
-/**
- * This string defines the order in which color channels are stored in the map
- * and eventually in what order the channels will be displayed to the user.
- */
-const std::string COLOR_CHANNELS = "CMYK" "RGB" "ADEFHIJLNOPQSTUVWXZ";
-
-/**
- * This struct is just here to compare two keys according to the order defined above
- */
-struct ColorComparator : public std::binary_function<std::string, std::string, bool> {
-public:
-  bool operator()(const std::string& key_a, const std::string& key_b) const {
-    return COLOR_CHANNELS.find(key_a) < COLOR_CHANNELS.find(key_b);
-  }
-};
-
 class PipetteLayerOperations : public virtual Scroom::Utils::Base
 {
 public:
   typedef boost::shared_ptr<PipetteLayerOperations> Ptr;
-  typedef std::map<std::string, double, ColorComparator> PipetteColor;
+  typedef std::vector<std::pair<std::string, double>> PipetteColor;
 
 public:
   virtual ~PipetteLayerOperations()

--- a/plugins/tiff/src/tiffpresentation.cc
+++ b/plugins/tiff/src/tiffpresentation.cc
@@ -411,10 +411,14 @@ void TiffPresentation::done()
  */
 PipetteLayerOperations::PipetteColor sumPipetteColors(const PipetteLayerOperations::PipetteColor& lhs, const PipetteLayerOperations::PipetteColor& rhs)
 {
-  PipetteLayerOperations::PipetteColor result = lhs;
-  for(auto const& elem : rhs)
+  PipetteLayerOperations::PipetteColor result;
+  if(lhs.empty())
   {
-    result[elem.first] += elem.second;
+    return rhs;
+  }
+  for(unsigned int i = 0; i < rhs.size(); i++ )
+  {
+    result.push_back({ rhs[i].first, rhs[i].second + lhs[i].second });
   }
   return result;
 }


### PR DESCRIPTION
Hey @kees-jan,
These should be the final changes for the pixel-averages support.
### Changes:
Changed datastructure to use a vector of pairs instead of a map. This also required the `sumPipetteColors` method to be changed, the `dividePipetteColors` method did not have to be changed.

regards,
Armin